### PR TITLE
docs: Random games

### DIFF
--- a/docs/signatures/gb.md
+++ b/docs/signatures/gb.md
@@ -834,6 +834,12 @@
 - Signature: `0x514d3f2c`
 - Magic Number: `0x04b1`
 
+## Pitman
+
+- CRC32: `0xa0b68136`
+- Signature: `0x4fc85da6`
+- Magic Number: `0x04b2`
+
 ## Pocket Bomberman (Europe)
 
 - CRC32: `0x0fd1ae54`
@@ -863,6 +869,12 @@
 - CRC32: `0x40e5adc9`
 - Signature: `0xb9c0b830`
 - Magic Number: `0x0502`
+
+## Quiz Sekai wa Show by Shoubai!!
+
+- CRC32: `0xd8c33dcd`
+- Signature: `0xbbcbc86b`
+- Magic Number: `0x0504`
 
 ## Red Arremer: Makai Mura Gaiden
 

--- a/docs/signatures/gba.md
+++ b/docs/signatures/gba.md
@@ -180,6 +180,12 @@
 - Signature: `0x4a6aa234`
 - Magic Number: `0x0f46`
 
+## Famicom Mini 09 - Bomberman
+
+- CRC32: `0xc1116e40`
+- Signature: `0xffdf70c1`
+- Magic Number: `0x0f46`
+
 ## Famicom Mini 11 - Mario Bros.
 
 - CRC32: `0x42a027ab`
@@ -197,6 +203,12 @@
 - CRC32: `0xa01f014a`
 - Signature: `0x59723945`
 - Magic Number: `0x0f49`
+
+## Famicom Mini 14 - Wrecking Crew
+
+- CRC32: `0xadac99bd`
+- Signature: `0x63b53a12`
+- Magic Number: `0x0f4b`
 
 ## Famicom Mini 16 - Dig Dug
 

--- a/docs/signatures/gba.md
+++ b/docs/signatures/gba.md
@@ -24,6 +24,12 @@
 - Signature: `0x6fc3aa2c`
 - Magic Number: `0x0d4b`
 
+## Bomber Man Jetters: Densetsu no Bomber Man
+
+- CRC32: `0x70c423b8`
+- Signature: `0x857018fd`
+- Magic Number: `0x0d53`
+
 ## Bomberman Tournament
 
 - CRC32: `0x240282e6`
@@ -138,6 +144,12 @@
 - Signature: `0xb2f00993`
 - Magic Number: `0x0f3e`
 
+## Famicom Mini 01 - Super Mario Bros. (Rev 1)
+
+- CRC32: `0xcd2604dd`
+- Signature: `0xad3bf77e`
+- Magic Number: `0x0f3e`
+
 ## Famicom Mini 03 - Ice Climber
 
 - CRC32: `0xd0aef472`
@@ -202,6 +214,12 @@
 
 - CRC32: `0x2f390212`
 - Signature: `0x4c2ff45f`
+- Magic Number: `0x0f4f`
+
+## Famicom Mini 18 - Makaimura
+
+- CRC32: `0x8a7964ca`
+- Signature: `0x821f8452`
 - Magic Number: `0x0f4f`
 
 ## Famicom Mini 21 - Super Mario Bros. 2
@@ -467,6 +485,12 @@
 - CRC32: `0xb17532ee`
 - Signature: `0xfa8f28f2`
 - Magic Number: `0x14a4`
+
+## Shaman King: Master of Spirits 2
+
+- CRC32: `0x201e3412`
+- Signature: `0xcab92e24`
+- Magic Number: `0x14c0`
 
 ## Sonic Advance
 

--- a/docs/signatures/gg.md
+++ b/docs/signatures/gg.md
@@ -126,6 +126,12 @@
 - Signature: `0x42da3fd6`
 - Magic Number: `0x1825`
 
+## Mappy
+
+- CRC32: `0x01d2dd2a`
+- Signature: `0x6a1f771e`
+- Magic Number: `0x1835`
+
 ## Psychic World (USA, Europe, Brazil)
 
 - CRC32: `0x73779b22`

--- a/docs/signatures/ngpc.md
+++ b/docs/signatures/ngpc.md
@@ -1,5 +1,11 @@
 # Neo Geo Pocket Color CRC32s, cartridge signatures, and magic numbers
 
+## Dynamite Slugger
+
+- CRC32: `0x7f1779cd`
+- Signature: `0xbed36ceb`
+- Magic Number: `0x1b3e`
+
 ## Fantastic Night Dreams Cotton (Japan)
 
 - CRC32: `0xb8a12409`

--- a/pkg/io/resources/gb.json
+++ b/pkg/io/resources/gb.json
@@ -974,6 +974,13 @@
   },
   {
     "system": 0,
+    "name": "Pitman",
+    "crc": "0xa0b68136",
+    "signature": "0x4fc85da6",
+    "magic": "0x04b2"
+  },
+  {
+    "system": 0,
     "name": "Pocket Bomberman (Europe)",
     "crc": "0x0fd1ae54",
     "signature": "0xcd6930e4",
@@ -1006,6 +1013,13 @@
     "crc": "0x40e5adc9",
     "signature": "0xb9c0b830",
     "magic": "0x0502"
+  },
+  {
+    "system": 0,
+    "name": "Quiz Sekai wa Show by Shoubai!!",
+    "crc": "0xd8c33dcd",
+    "signature": "0xbbcbc86b",
+    "magic": "0x0504"
   },
   {
     "system": 0,

--- a/pkg/io/resources/gba.json
+++ b/pkg/io/resources/gba.json
@@ -211,6 +211,13 @@
   },
   {
     "system": 2,
+    "name": "Famicom Mini 09 - Bomberman",
+    "crc": "0xc1116e40",
+    "signature": "0xffdf70c1",
+    "magic": "0x0f46"
+  },
+  {
+    "system": 2,
     "name": "Famicom Mini 11 - Mario Bros.",
     "crc": "0x42a027ab",
     "signature": "0x6d0563a3",
@@ -229,6 +236,13 @@
     "crc": "0xa01f014a",
     "signature": "0x59723945",
     "magic": "0x0f49"
+  },
+  {
+    "system": 2,
+    "name": "Famicom Mini 14 - Wrecking Crew",
+    "crc": "0xadac99bd",
+    "signature": "0x63b53a12",
+    "magic": "0x0f4b"
   },
   {
     "system": 2,

--- a/pkg/io/resources/gba.json
+++ b/pkg/io/resources/gba.json
@@ -29,6 +29,13 @@
   },
   {
     "system": 2,
+    "name": "Bomber Man Jetters: Densetsu no Bomber Man",
+    "crc": "0x70c423b8",
+    "signature": "0x857018fd",
+    "magic": "0x0d53"
+  },
+  {
+    "system": 2,
     "name": "Bomberman Tournament",
     "crc": "0x240282e6",
     "signature": "0xaa3373c7",
@@ -162,6 +169,13 @@
   },
   {
     "system": 2,
+    "name": "Famicom Mini 01 - Super Mario Bros. (Rev 1)",
+    "crc": "0xcd2604dd",
+    "signature": "0xad3bf77e",
+    "magic": "0x0f3e"
+  },
+  {
+    "system": 2,
     "name": "Famicom Mini 03 - Ice Climber",
     "crc": "0xd0aef472",
     "signature": "0x19de64ca",
@@ -235,6 +249,13 @@
     "name": "Famicom Mini 19 - Twin Bee",
     "crc": "0x2f390212",
     "signature": "0x4c2ff45f",
+    "magic": "0x0f4f"
+  },
+  {
+    "system": 2,
+    "name": "Famicom Mini 18 - Makaimura",
+    "crc": "0x8a7964ca",
+    "signature": "0x821f8452",
     "magic": "0x0f4f"
   },
   {
@@ -544,6 +565,13 @@
     "crc": "0xb17532ee",
     "signature": "0xfa8f28f2",
     "magic": "0x14a4"
+  },
+  {
+    "system": 2,
+    "name": "Shaman King: Master of Spirits 2",
+    "crc": "0x201e3412",
+    "signature": "0xcab92e24",
+    "magic": "0x14c0"
   },
   {
     "system": 2,

--- a/pkg/io/resources/gg.json
+++ b/pkg/io/resources/gg.json
@@ -148,6 +148,13 @@
   },
   {
     "system": 3,
+    "name": "Mappy",
+    "crc": "0x01d2dd2a",
+    "signature": "0x6a1f771e",
+    "magic": "0x1835"
+  },
+  {
+    "system": 3,
     "name": "Psychic World (USA, Europe, Brazil)",
     "crc": "0x73779b22",
     "signature": "0xab844ea6",

--- a/pkg/io/resources/ngpc.json
+++ b/pkg/io/resources/ngpc.json
@@ -1,6 +1,13 @@
 [
   {
     "system": 6,
+    "name": "Dynamite Slugger",
+    "crc": "0x7f1779cd",
+    "signature": "0xbed36ceb",
+    "magic": "0x1b3e"
+  },
+  {
+    "system": 6,
     "name": "Fantastic Night Dreams Cotton (Japan)",
     "crc": "0xb8a12409",
     "signature": "0x74e36925",


### PR DESCRIPTION
Interesting that a number of Famicom Mini entries appear to have collisions on the magic number.

I had assumed that was an internal map key, but it appears not.